### PR TITLE
Remove unused Go import

### DIFF
--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -4,7 +4,6 @@
 package examples
 
 import (
-	"path/filepath"
 	"testing"
 
 	"github.com/pulumi/pulumi/pkg/v3/testing/integration"


### PR DESCRIPTION
Removed an unused Go import to let `make test` work, although nothing is actually set up.

Replaces #54 

Signed-off-by: Ringo De Smet <ringo@de-smet.name>