### PR TITLE
Docs required for registry publishing

### DIFF
--- a/docs/_index.md
+++ b/docs/_index.md
@@ -1,0 +1,82 @@
+---
+title: Unifi
+meta_desc: Provides an overview of the Unifi Provider for Pulumi.
+layout: overview
+---
+
+The Unifi provider for Pulumi can be used to provision any of the network resources available in a Unifi based network controlled by a Unifi controller.
+The Unifi provider must be configured with credentials to deploy and update resources in Unifi.
+
+## Example
+
+{{< chooser language "typescript,python,go,csharp" >}}
+{{% choosable language typescript %}}
+
+```typescript
+import * as pulumi from "@pulumi/pulumi";
+import * as unifi from "@pulumi/unifi";
+
+const mysite = new unifi.Site("mysite", {
+    description: "mysite",
+});
+```
+ 
+{{% /choosable %}}
+{{% choosable language python %}}
+
+```python
+import pulumiverse_unifi as unifi
+
+db = unifi.Site("mysite",
+    description="mysite"
+)
+```
+
+{{% /choosable %}}
+{{% choosable language go %}}
+
+```go
+import (
+	"fmt"
+	unifi "github.com/pulumiverse/pulumi-unifi/sdk/go/unifi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+
+		site, err := unifi.NewSite(ctx, "mysite", &unifi.SiteArgs{
+            Description: pulumi.String("mysite"),
+		})
+		if err != nil {
+			return fmt.Errorf("error creating site: %v", err)
+		}
+
+		ctx.Export("dbId", site.Id)
+
+		return nil
+	})
+}
+```
+
+{{% /choosable %}}
+{{% choosable language csharp %}}
+
+```csharp
+using Pulumi;
+using Pulumiverse.Unifi;
+
+class UnifiNet : Stack
+{
+    public UnifiNet()
+    {
+        var db = new Site("mysite", new SiteArgs{
+            Descriptino: "mysite"
+        });
+    }
+}
+```
+
+{{% /choosable %}}
+
+{{< /chooser >}}

--- a/docs/installation-configuration.md
+++ b/docs/installation-configuration.md
@@ -1,0 +1,28 @@
+---
+title: Unifi Setup
+meta_desc: Information on how to install the Unifi provider.
+layout: installation
+---
+
+## Installation
+
+The Pulumiverse Unifi provider is available as a package in all Pulumi languages:
+
+* JavaScript/TypeScript: [`@pulumiverse/unifi`](https://www.npmjs.com/package/@pulumiverse/unifi)
+* Python: [`pulumiverse_unifi`](https://pypi.org/project/pulumiverse-unifi/)
+* Go: [`github.com/pulumiverse/pulumi-unifi/sdk/go/unifi`](https://pkg.go.dev/github.com/pulumiverse/pulumi-unifi/sdk)
+* .NET: [`Pulumiverse.Unifi`](https://www.nuget.org/packages/Pulumiverse.Unifi)
+
+## Setup
+
+To provision resources with the Pulumi Unifi provider, you need to have correct endpoint configuration towards your Unifi controller.
+
+## Configuration Options
+
+Use `pulumi config set unifi:<option> (--secret)`.
+
+| Option | Environment Variable | Required/Optional | Description | 
+|-----|------|------|----|
+| `username`| `UNIFI_USERNAME` | Required | Unifi user name |
+| `password`| `UNIFI_PASSWORD` | Required (Secret) | Unifi Password |
+| `api_url`| `UNIFI_API` | Required | Unifi user name |


### PR DESCRIPTION
The `docs` folder with the 2 files in it are required for publishing this provider to the Pulumi Registry. Each file maps to a tab on the listing in the registry:

* `_index.md` -> `Overview`
* `installation-configuration.md` -> `Installation & Configuration`

See https://www.pulumi.com/registry/packages/astra/ for an example.

Signed-off-by: Ringo De Smet <ringo@de-smet.name>