### PR TITLE
Lowering the rate of scheduled dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,16 +3,14 @@ updates:
 - package-ecosystem: gomod
   directory: "/provider"
   schedule:
-    interval: weekly
-    time: "13:00"
+    interval: monthly
   open-pull-requests-limit: 3
   reviewers:
   - ringods
 - package-ecosystem: gomod
   directory: "/sdk"
   schedule:
-    interval: daily
-    time: "13:00"
+    interval: monthly
   open-pull-requests-limit: 3
   reviewers:
   - ringods


### PR DESCRIPTION
Lowering the rate at which dependency update PRs come in. Besides the planned updates, now monthly, there can still be other PRs come in. See the `Note` in the docs of `schedule.interval`:

https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#scheduleinterval

Signed-off-by: Ringo De Smet <ringo@de-smet.name>