### PR TITLE
fix unifi logo + seo fix

### DIFF
--- a/docs/installation-configuration.md
+++ b/docs/installation-configuration.md
@@ -1,5 +1,5 @@
 ---
-title: Unifi Setup
+title: Unifi Installation & Configuration
 meta_desc: Information on how to install the Unifi provider.
 layout: installation
 ---

--- a/provider/cmd/pulumi-resource-unifi/schema.json
+++ b/provider/cmd/pulumi-resource-unifi/schema.json
@@ -11,7 +11,7 @@
     "license": "Apache-2.0",
     "attribution": "This Pulumi package is based on the [`unifi` Terraform Provider](https://github.com/paultyng/terraform-provider-unifi).",
     "repository": "https://github.com/pulumiverse/pulumi-unifi",
-    "logoUrl": "https://raw.githubusercontent.com/pulumiverse/.github/main/assets/mascot.png",
+    "logoUrl": "",
     "pluginDownloadURL": "github://api.github.com/pulumiverse",
     "publisher": "Pulumiverse",
     "meta": {


### PR DESCRIPTION
hi folks, we have a unifi logo available in the pulumi-hugo repo, so if you drop this mascot url it will get picked up and used automatically in the registry.

this also includes an seo fix for the install+config docs page

after yall merge this, it requires a new release for the registry to know about it.