### PR TITLE
Upgrade all pulumi dependencies together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,11 @@ updates:
   schedule:
     interval: monthly
   open-pull-requests-limit: 3
+  # Upgrade all pulumi dependencies together.
+  groups:
+      pulumi-dependencies:
+        patterns:
+          - "github.com/pulumi/*"
   reviewers:
   - ringods
 - package-ecosystem: gomod
@@ -12,6 +17,11 @@ updates:
   schedule:
     interval: monthly
   open-pull-requests-limit: 3
+  # Upgrade all pulumi dependencies together.
+  groups:
+      pulumi-dependencies:
+        patterns:
+          - "github.com/pulumi/*"
   reviewers:
   - ringods
 - package-ecosystem: "github-actions"


### PR DESCRIPTION
New feature available in Dependabot:

https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/

Update the config file to bundle Pulumi Go dependencies in a single PR.