### PR TITLE
Only track terraform-bridge in `/provider`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,11 +5,8 @@ updates:
   schedule:
     interval: monthly
   open-pull-requests-limit: 3
-  # Upgrade all pulumi dependencies together.
-  groups:
-      pulumi-dependencies:
-        patterns:
-          - "github.com/pulumi/*"
+  ignore:
+    - dependency-name: "github.com/pulumi/pulumi/sdk/*"
   reviewers:
   - ringods
 - package-ecosystem: gomod
@@ -17,11 +14,6 @@ updates:
   schedule:
     interval: monthly
   open-pull-requests-limit: 3
-  # Upgrade all pulumi dependencies together.
-  groups:
-      pulumi-dependencies:
-        patterns:
-          - "github.com/pulumi/*"
   reviewers:
   - ringods
 - package-ecosystem: "github-actions"


### PR DESCRIPTION
In `/provider`, the terraform bridge has its own locked version on `pulumi/sdk/v3`. Hence, configure Dependabot to ignore upgrading `pulumi/sdk/v3` for `provider`.

The version of `pulumi/sdk/v3` needs to remain the same in `/sdk` but there is no way to solve this with Dependabot.