### PR TITLE
Fix workflow dependency

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,7 +136,7 @@ jobs:
     name: build_sdk
   publish:
     runs-on: ubuntu-latest
-    needs: test
+    needs: build_sdk
     name: publish
     steps:
     - name: Checkout repo


### PR DESCRIPTION
Update the job dependency from non-existing `test` to previous step `build_sdk`.

Should fix the failing release workflow.
https://github.com/pulumiverse/pulumi-unifi/actions/runs/6246073161