### PR TITLE
Improve the Renovate update PRs for Github Actions workflows

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,8 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": [
-        ":semanticCommitScopeDisabled",
+        "helpers:pinGitHubActionDigests",
+        "group:githubArtifactActions",
         "schedule:earlyMondays"
     ],
     "packageRules": [


### PR DESCRIPTION
I'm not satisfied with the current configuration of Renovate to get automated update pull requests, hence I will slowly review any created PR from Renovate and see if tweaks are needed to the configuration.

This first PR attempts to improve the updates for Github Actions used in the GHA workflows with the following:

* [keep versions of `upload-artifact` and `download-artifact` in sync](https://docs.renovatebot.com/presets-group/#groupgithubartifactactions)
* [pin third-party GitHub Actions to a full-length commit SHA](https://docs.renovatebot.com/upgrade-best-practices/#extends-helperspingithubactiondigests)