### PR TITLE
Add go.work.sum to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ sdk/java/gradlew
 sdk/java/gradlew.bat
 
 .envrc
+
+go.work.sum


### PR DESCRIPTION
`go.work.sum` is no longer under source control. Adding it to `.gitignore` to prevent it from being re-committed.