### PR TITLE
Ignore Go dependency upgrades done by the `upgrade-provider` tool

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,7 +5,23 @@
         "group:githubArtifactActions",
         "schedule:earlyMondays"
     ],
+    "constraints": {
+        "go": "1.22"
+    },
     "packageRules": [
+        {
+            "matchFileNames": [
+                "provider/**"
+            ],
+            "matchDatasources": [
+                "go"
+            ],
+            "excludePackagePrefixes": [
+                "github.com/hashicorp/terraform-plugin-sdk",
+                "github.com/pulumi/pulumi",
+                "github.com/paultyng/terraform-provider-unifi"
+            ]
+        },
         {
             "matchFileNames": [
                 "examples/**"


### PR DESCRIPTION
Another tweak to lower the number of PRs created by Renovate. This PR is intended so Renovate no longer creates PRs for the dependencies which are updated by the `upgrade-provider` tool.

I added a rule block to check:

* `matchFileNames`: the files in the `provider/` subfolder, including `provider/shim/`
* `matchDatasources`: only process Go project files (`go.mod`, `go.sum`)
* exclude the dependencies which get upgraded via the `upgrade-provider` tool:
  * `github.com/hashicorp/terraform-plugin-sdk/*`
  * `github.com/pulumi/pulumi*` (core Pulumi SDK with `pkg` and `sdk` modules, as well as `pulumi-terraform-bridge`)
  * `github.com/paultyng/terraform-provider-unifi/*` (the upstream TF provider)
* Do not upgrade to a newer Go version than 1.22 if it is released. Upgrading the Go version should follow the release cycle from Pulumi.

Pull request like #172, #182 and #183 should no longer be created.