### PR TITLE
Update renovate config to ignore pulumi dependencies in different directories

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -18,6 +18,7 @@
             ],
             "matchPackageNames": [
                 "!github.com/hashicorp/terraform-plugin-sdk",
+                "!github.com/pulumi/terraform-plugin-sdk",
                 "!github.com/pulumi/pulumi/*",
                 "!github.com/paultyng/terraform-provider-unifi"
             ]

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -32,6 +32,28 @@
         },
         {
             "matchFileNames": [
+                "examples/**"
+            ],
+            "matchDatasources": [
+                "pypi"
+            ],
+            "matchPackageNames": [
+                "!pulumi*"
+            ]
+        },
+        {
+            "matchFileNames": [
+                "examples/**"
+            ],
+            "matchDatasources": [
+                "npm"
+            ],
+            "matchPackageNames": [
+                "!@pulumi/pulumi"
+            ]
+        },
+        {
+            "matchFileNames": [
                 "sdk/**"
             ],
             "enabled": false

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -16,10 +16,10 @@
             "matchDatasources": [
                 "go"
             ],
-            "excludePackagePrefixes": [
-                "github.com/hashicorp/terraform-plugin-sdk",
-                "github.com/pulumi/pulumi",
-                "github.com/paultyng/terraform-provider-unifi"
+            "matchPackageNames": [
+                "!github.com/hashicorp/terraform-plugin-sdk",
+                "!github.com/pulumi/pulumi/*",
+                "!github.com/paultyng/terraform-provider-unifi"
             ]
         },
         {


### PR DESCRIPTION
- Renovate v38 only uses `matchPackagesNames` as package filter. See https://docs.renovatebot.com/release-notes-for-major-versions/#changes-to-package-matching
- Exclude example dir for renovate
- Exclude `github.com/pulumi/terraform-plugin-sdk` from renovate